### PR TITLE
Remove setting of environment variable DELEGATE_AUTHORIZED ROLES

### DIFF
--- a/docker-compose-metric.yml
+++ b/docker-compose-metric.yml
@@ -146,7 +146,6 @@ services:
       KEYSTONE_AUTH_URI: ${MON_KEYSTONE_URL}
       KEYSTONE_ADMIN_USER: ${MON_KEYSTONE_ADMIN_USER}
       KEYSTONE_ADMIN_PASSWORD: ${MON_KEYSTONE_ADMIN_PASSWORD}
-      DELEGATE_AUTHORIZED_ROLES: "monitoring-delegate"
     depends_on:
       - influxdb
       - mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,7 +172,6 @@ services:
     restart: on-failure
     environment:
       LOGSTASH_FIELDS: "service=monasca-api"
-      DELEGATE_AUTHORIZED_ROLES: "monitoring-delegate"
     depends_on:
       - influxdb
       - keystone


### PR DESCRIPTION
for monasca-api. Thus, the default (admin) role will be taken.