### PR TITLE
Eliminate warnings on start of monasca-thresh

### DIFF
--- a/storm/build.yml
+++ b/storm/build.yml
@@ -1,6 +1,6 @@
 repository: fest/storm
 variants:
-  - tag: 2.0.3
+  - tag: 2.0.4
     aliases:
       - :pike-{date}-{time}
     args:

--- a/storm/templates/storm.yaml.j2
+++ b/storm/templates/storm.yaml.j2
@@ -22,9 +22,9 @@ storm.zookeeper.servers:
 {% endfor %}
 storm.zookeeper.port: {{ STORM_ZOOKEEPER_PORT | default('2181') }}
 storm.zookeeper.retry.interval: {{ STORM_ZOOKEEPER_RETRY_INTERVAL | default('5000') }}
-storm.zookeeper.retry.times: {{ STORM_ZOOKEEPER_RETRY_TIMES | default('60') }}
+storm.zookeeper.retry.times: {{ STORM_ZOOKEEPER_RETRY_TIMES | default('10') }}
 storm.zookeeper.root: {{ STORM_ZOOKEEPER_ROOT | default ('/storm') }}
-storm.zookeeper.session.timeout: {{ STORM_ZOOKEEPER_SESSION_TIMEOUT | default('3000') }}
+storm.zookeeper.session.timeout: {{ STORM_ZOOKEEPER_SESSION_TIMEOUT | default('20000') }}
 
 supervisor.slots.ports:
 {% for port in SUPERVISOR_SLOTS_PORTS.split(',') %}


### PR DESCRIPTION
When -thresh is started, storm and zookeeper are started (local mode).
Zookeeper config. is stored in “storm.yaml.j2”.
There, 2 default settings cause warnings and need to be adjusted:

storm.zookeeper.retry.times: 60 (too high) -> 10
storm.zookeeper.session.timeout: 3000 (lower than connection timeout)
                                 -> 20000 (default value)

Additional change: incr. version-# for storm image

Signed-off-by: bandorf <matthias.bandorf@est.fujitsu.com>