### PR TITLE
Modify config. for thresh to reduce load

### DIFF
--- a/docker-compose-metric.yml
+++ b/docker-compose-metric.yml
@@ -104,7 +104,7 @@ services:
       KAFKA_DELETE_TOPIC_ENABLE: "true"
       KAFKA_TOPIC_CONFIG: segment.ms=900000 # 15m
       KAFKA_CREATE_TOPICS: "\
-        metrics:64:1,\
+        metrics:16:1,\
         alarm-state-transitions:12:1,\
         alarm-notifications:12:1,\
         retry-notifications:3:1,\
@@ -174,7 +174,7 @@ services:
     restart: unless-stopped
     environment:
       NO_STORM_CLUSTER: "true"
-      WORKER_MAX_HEAP_MB: "256"
+      WORKER_MAX_HEAP_MB: "768"
       LOGSTASH_FIELDS: "service=monasca-thresh"
       LOG_LEVEL: "info"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       KAFKA_DELETE_TOPIC_ENABLE: "true"
       KAFKA_TOPIC_CONFIG: segment.ms=900000 # 15m
       KAFKA_CREATE_TOPICS: "\
-        metrics:64:1,\
+        metrics:16:1,\
         alarm-state-transitions:12:1,\
         alarm-notifications:12:1,\
         retry-notifications:3:1,\
@@ -201,7 +201,7 @@ services:
     restart: on-failure
     environment:
       NO_STORM_CLUSTER: "true"
-      WORKER_MAX_HEAP_MB: "256"
+      WORKER_MAX_HEAP_MB: "768"
       LOGSTASH_FIELDS: "service=monasca-thresh"
       LOG_LEVEL: "info"
     depends_on:

--- a/storm/templates/storm.yaml.j2
+++ b/storm/templates/storm.yaml.j2
@@ -57,3 +57,4 @@ transactional.zookeeper.root: {{ TRANSACTIONAL_ZOOKEEPER_ROOT | default('/storm-
 
 topology.acker.executors: {{ TOPOLOGY_ACKER_EXECUTORS | default('1') }}
 topology.debug: {{ TOPOLOG_DEBUG | default('false') }}
+topology.max.spout.pending: {{ TOPOLOG_MAX_SPOUT_PENDING | default('500') }}


### PR DESCRIPTION
Provide a default config. to reduce load on server:
- less partitions for kafka consumers
- more heap for thresh workers
- limit # of concurrently handled entries in thresh